### PR TITLE
Enable networking in sandbox

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -305,7 +305,7 @@ inherit = "none"
 set = { PATH = "/usr/bin", MY_FLAG = "1" }
 ```
 
-Currently, `CODEX_SANDBOX_NETWORK_DISABLED=1` is also added to the environment, assuming network is disabled. This is not configurable.
+Previously, `CODEX_SANDBOX_NETWORK_DISABLED=1` was added to the environment when network access was disabled. This variable is no longer set.
 
 ## notify
 

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use codex_core::Codex;
 use codex_core::ModelProviderInfo;
-use codex_core::exec::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_core::protocol::ErrorEvent;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
@@ -54,13 +53,6 @@ data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"output\":
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn keeps_previous_response_id_between_tasks() {
     #![allow(clippy::unwrap_used)]
-
-    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
 
     // Mock server
     let server = MockServer::start().await;

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use codex_core::Codex;
 use codex_core::ModelProviderInfo;
-use codex_core::exec::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
@@ -38,12 +37,6 @@ data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"output\":
 async fn retries_on_early_close() {
     #![allow(clippy::unwrap_used)]
 
-    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
 
     let server = MockServer::start().await;
 


### PR DESCRIPTION
## Summary
- stop injecting `CODEX_SANDBOX_NETWORK_DISABLED` when running tools
- always enable networking when spawning seatbelt and linux sandboxes
- drop test skips that relied on the env var
- update docs about the removed env var

## Testing
- `cargo test -p codex-core -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6869311cff4c8328ad0205c8d43d28f9