### PR TITLE
Add gemini-cli provider

### DIFF
--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -103,6 +103,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - openrouter
 > - azure
 > - gemini
+> - gemini-cli
 > - ollama
 > - mistral
 > - deepseek
@@ -414,6 +415,11 @@ Below is a comprehensive example of `config.json` with multiple custom providers
       "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai",
       "envKey": "GEMINI_API_KEY"
     },
+    "gemini-cli": {
+      "name": "Gemini CLI",
+      "baseURL": "",
+      "envKey": "GEMINI_API_KEY"
+    },
     "ollama": {
       "name": "Ollama",
       "baseURL": "http://localhost:11434/v1",
@@ -476,6 +482,9 @@ export AZURE_OPENAI_API_VERSION="2025-04-01-preview" (Optional)
 
 # OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-key-here"
+
+# Gemini CLI
+export GEMINI_API_KEY="your-gemini-key-here"
 
 # Similarly for other providers
 ```

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -2,52 +2,57 @@ export const providers: Record<
   string,
   { name: string; baseURL: string; envKey: string }
 > = {
-  openai: {
+  "openai": {
     name: "OpenAI",
     baseURL: "https://api.openai.com/v1",
     envKey: "OPENAI_API_KEY",
   },
-  openrouter: {
+  "openrouter": {
     name: "OpenRouter",
     baseURL: "https://openrouter.ai/api/v1",
     envKey: "OPENROUTER_API_KEY",
   },
-  azure: {
+  "azure": {
     name: "AzureOpenAI",
     baseURL: "https://YOUR_PROJECT_NAME.openai.azure.com/openai",
     envKey: "AZURE_OPENAI_API_KEY",
   },
-  gemini: {
+  "gemini": {
     name: "Gemini",
     baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
     envKey: "GEMINI_API_KEY",
   },
-  ollama: {
+  "gemini-cli": {
+    name: "Gemini CLI",
+    baseURL: "",
+    envKey: "GEMINI_API_KEY",
+  },
+  "ollama": {
     name: "Ollama",
     baseURL: "http://localhost:11434/v1",
     envKey: "OLLAMA_API_KEY",
   },
-  mistral: {
+  "mistral": {
     name: "Mistral",
     baseURL: "https://api.mistral.ai/v1",
     envKey: "MISTRAL_API_KEY",
   },
-  deepseek: {
+  "deepseek": {
     name: "DeepSeek",
     baseURL: "https://api.deepseek.com",
     envKey: "DEEPSEEK_API_KEY",
   },
-  xai: {
+  "xai": {
     name: "xAI",
     baseURL: "https://api.x.ai/v1",
     envKey: "XAI_API_KEY",
   },
-  groq: {
+  "groq": {
     name: "Groq",
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
-  arceeai: {
+  "arceeai": {
     name: "ArceeAI",
     baseURL: "https://conductor.arcee.ai/v1",
     envKey: "ARCEEAI_API_KEY",


### PR DESCRIPTION
## Summary
- support gemini-cli via child_process in OpenAI client
- list `gemini-cli` in provider registry and docs
- document GEMINI_API_KEY usage for the CLI

## Testing
- `pnpm --filter @openai/codex lint`
- `cd codex-cli && pnpm run typecheck`
- `pnpm --filter @openai/codex test`

------
https://chatgpt.com/codex/tasks/task_e_687198c879e88328b186c52df389bb3d